### PR TITLE
Replace File with FormData for OpenAI upload

### DIFF
--- a/app/api/vector_stores/upload_file/route.ts
+++ b/app/api/vector_stores/upload_file/route.ts
@@ -10,8 +10,11 @@ export async function POST(request: Request) {
       type: "application/octet-stream",
     });
 
+    const form = new FormData();
+    form.append("file", fileBlob, fileObject.name);
+
     const file = await openai.files.create({
-      file: new File([fileBlob], fileObject.name),
+      file: form.get("file") as File,
       purpose: "assistants",
     });
 


### PR DESCRIPTION
## Summary
- use `FormData` instead of `new File` when uploading a blob

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684822c0de6c8322bcc7175ae856f7b0