### PR TITLE
Fix store creation request body

### DIFF
--- a/components/file-upload.tsx
+++ b/components/file-upload.tsx
@@ -131,7 +131,7 @@ export default function FileUpload({
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            storeName: newStoreName,
+            name: newStoreName,
           }),
         });
         if (!createResponse.ok) {


### PR DESCRIPTION
## Summary
- send `name` instead of `storeName` when creating a vector store
- ensure the route reads the `name` field to create the store

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684822b333888322a1fa382a2a743796