### PR TITLE
Improve worker creation flow

### DIFF
--- a/app/header.tsx
+++ b/app/header.tsx
@@ -1,12 +1,11 @@
-'use client'
-import Link from 'next/link'
+"use client";
+import Link from "next/link";
 
 export default function Header() {
   return (
     <header className="p-4 bg-white shadow flex gap-4">
-      <Link href="/">Chat</Link>
       <Link href="/workers/new">Create Worker</Link>
       <Link href="/store">Marketplace</Link>
     </header>
-  )
+  );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,37 +1,6 @@
-"use client";
-import Assistant from "@/components/assistant";
-import ToolsPanel from "@/components/tools-panel";
-import { Menu, X } from "lucide-react";
-import { useState } from "react";
+import { redirect } from "next/navigation";
 
-export default function Main() {
-  const [isToolsPanelOpen, setIsToolsPanelOpen] = useState(false);
-
-  return (
-    <div className="flex justify-center h-screen">
-      <div className="w-full md:w-[70%]">
-        <Assistant />
-      </div>
-      <div className=" hidden md:block w-[30%]">
-        <ToolsPanel />
-      </div>
-      {/* Hamburger menu for small screens */}
-      <div className="absolute top-4 right-4 md:hidden">
-        <button onClick={() => setIsToolsPanelOpen(true)}>
-          <Menu size={24} />
-        </button>
-      </div>
-      {/* Overlay panel for ToolsPanel on small screens */}
-      {isToolsPanelOpen && (
-        <div className="fixed inset-0 z-50 flex justify-end bg-black bg-opacity-30">
-          <div className="w-full bg-white h-full p-4">
-            <button className="mb-4" onClick={() => setIsToolsPanelOpen(false)}>
-              <X size={24} />
-            </button>
-            <ToolsPanel />
-          </div>
-        </div>
-      )}
-    </div>
-  );
+export default function Home() {
+  redirect("/workers/new");
+  return null;
 }

--- a/app/workers/new/page.tsx
+++ b/app/workers/new/page.tsx
@@ -1,107 +1,37 @@
 "use client";
-import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
-import { Button } from "@/components/ui/button";
+import { useRef } from "react";
 import Assistant from "@/components/assistant";
-import useWorkerFormStore from "@/stores/useWorkerFormStore";
-import { useRouter } from "next/navigation";
+import { createConversationStore } from "@/stores/createConversationStore";
+import {
+  WORKER_WIZARD_DEVELOPER_PROMPT,
+  WORKER_WIZARD_INITIAL_MESSAGE,
+  INITIAL_MESSAGE,
+} from "@/config/constants";
 
 export default function NewWorkerPage() {
-  const router = useRouter();
-  const {
-    role,
-    name,
-    traits,
-    step,
-    setRole,
-    setName,
-    setTraits,
-    nextStep,
-    prevStep,
-    reset,
-  } = useWorkerFormStore();
-
-  const handleSubmit = async () => {
-    await fetch("/api/workers", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ role, name, traits }),
-    });
-    reset();
-    router.push("/store");
-  };
+  const wizardStore = useRef(
+    createConversationStore(WORKER_WIZARD_INITIAL_MESSAGE),
+  ).current;
+  const previewStore = useRef(createConversationStore(INITIAL_MESSAGE)).current;
 
   return (
-    <div className="flex h-screen">
-      <div className="w-full md:w-1/2 p-6 bg-white overflow-y-auto space-y-6">
-        {step === 1 && (
-          <div className="space-y-4">
-            <div>
-              <label htmlFor="role" className="text-sm font-medium">
-                Role
-              </label>
-              <Input
-                id="role"
-                value={role}
-                onChange={(e) => setRole(e.target.value)}
-                placeholder="Customer support"
-              />
-            </div>
-            <div>
-              <label htmlFor="name" className="text-sm font-medium">
-                Name
-              </label>
-              <Input
-                id="name"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                placeholder="Alex"
-              />
-            </div>
-          </div>
-        )}
-        {step === 2 && (
-          <div className="space-y-4">
-            <div>
-              <label htmlFor="traits" className="text-sm font-medium">
-                Persona traits
-              </label>
-              <Textarea
-                id="traits"
-                value={traits}
-                onChange={(e) => setTraits(e.target.value)}
-                placeholder="Friendly, helpful..."
-              />
-            </div>
-          </div>
-        )}
-        {step === 3 && (
-          <div className="space-y-2">
-            <h2 className="text-lg font-medium">Summary</h2>
-            <p>
-              <strong>Role:</strong> {role}
-            </p>
-            <p>
-              <strong>Name:</strong> {name}
-            </p>
-            <p>
-              <strong>Traits:</strong> {traits}
-            </p>
-          </div>
-        )}
-        <div className="flex justify-between pt-4">
-          {step > 1 && (
-            <Button variant="secondary" onClick={prevStep}>
-              Back
-            </Button>
-          )}
-          {step < 3 && <div className="grow" />}
-          {step < 3 && <Button onClick={nextStep}>Next</Button>}
-          {step === 3 && <Button onClick={handleSubmit}>Create</Button>}
+    <div className="flex h-screen divide-x divide-gray-200">
+      <div className="w-full md:w-1/2 flex flex-col">
+        <div className="p-4 bg-gray-50 border-b font-semibold">
+          Create Worker
+        </div>
+        <div className="flex-1 overflow-hidden">
+          <Assistant
+            store={wizardStore}
+            developerPrompt={WORKER_WIZARD_DEVELOPER_PROMPT}
+          />
         </div>
       </div>
-      <div className="hidden md:block w-1/2">
-        <Assistant />
+      <div className="hidden md:flex w-1/2 flex-col">
+        <div className="p-4 bg-gray-50 border-b font-semibold">Preview</div>
+        <div className="flex-1 overflow-hidden">
+          <Assistant store={previewStore} />
+        </div>
       </div>
     </div>
   );

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -16,6 +16,27 @@ export const INITIAL_MESSAGE = `
 Hi, how can I help you?
 `;
 
+export const WORKER_WIZARD_DEVELOPER_PROMPT = `
+You are a friendly AI assistant helping someone create their AI Worker. Generate the next question in a warm, conversational way.
+
+GUIDELINES:
+1. Be conversational, warm, encouraging.
+2. Ask concise questions that build on previous answers.
+3. Reference known info (e.g., "Now that I know Alex will be a Marketing Analyst…").
+4. Adapt tone to match the user.
+
+FIELD RULES:
+• role  (2–50 chars)  → Only professional job titles.  
+• name  (2–30 chars)  → Human names (letters / spaces / hyphens / apostrophes).  
+• description (20–500)  
+• expertise (≤100 chars or “none”)  
+• skills (comma-separated or “none”)  
+
+Important: never put roles in “name” field, never put names in “role” field.
+`;
+
+export const WORKER_WIZARD_INITIAL_MESSAGE = `Let's create your AI Worker! What professional role should this worker have?`;
+
 export const defaultVectorStore = {
   id: "",
   name: "Example",

--- a/stores/createConversationStore.ts
+++ b/stores/createConversationStore.ts
@@ -1,0 +1,28 @@
+import { create } from "zustand";
+import { ConversationState } from "./useConversationStore";
+import { Item } from "@/lib/assistant";
+
+export const createConversationStore = (initialMessage: string) =>
+  create<ConversationState>((set) => ({
+    chatMessages: [
+      {
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: initialMessage }],
+      },
+    ],
+    conversationItems: [],
+    isAssistantLoading: false,
+    setChatMessages: (items: Item[]) => set({ chatMessages: items }),
+    setConversationItems: (messages: any[]) =>
+      set({ conversationItems: messages }),
+    addChatMessage: (item: Item) =>
+      set((state) => ({ chatMessages: [...state.chatMessages, item] })),
+    addConversationItem: (message) =>
+      set((state) => ({
+        conversationItems: [...state.conversationItems, message],
+      })),
+    setAssistantLoading: (loading: boolean) =>
+      set({ isAssistantLoading: loading }),
+    rawSet: set,
+  }));

--- a/stores/useConversationStore.ts
+++ b/stores/useConversationStore.ts
@@ -3,7 +3,7 @@ import { Item } from "@/lib/assistant";
 import { ChatCompletionMessageParam } from "openai/resources/chat/completions";
 import { INITIAL_MESSAGE } from "@/config/constants";
 
-interface ConversationState {
+export interface ConversationState {
   // Items displayed in the chat
   chatMessages: Item[];
   // Items sent to the Responses API


### PR DESCRIPTION
## Summary
- drop Chat navigation entry and redirect homepage to new worker flow
- support custom conversation stores for assistants
- add AI Worker creation wizard constants and store
- overhaul `/workers/new` into chat-based wizard with preview pane

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684836cb90d88322a2b9873b25baac14