### PR TITLE
Improve worker avatar display

### DIFF
--- a/app/workers/new/page.tsx
+++ b/app/workers/new/page.tsx
@@ -110,8 +110,20 @@ export default function NewWorkerPage() {
           )}
           <span>{name ? `${name} Preview` : "Preview"}</span>
         </div>
-        <div className="flex-1 overflow-hidden">
-          <Assistant store={previewStore} developerPrompt={previewPrompt} />
+        <div className="flex-1 overflow-hidden flex flex-col items-center">
+          {avatarUrl && (
+            <img
+              src={avatarUrl}
+              alt="avatar"
+              className="w-32 h-32 rounded-full mt-6 mb-2"
+            />
+          )}
+          <Assistant
+            store={previewStore}
+            developerPrompt={previewPrompt}
+            assistantAvatarUrl={avatarUrl}
+            showAssistantAvatar
+          />
         </div>
       </div>
     </div>

--- a/components/assistant.tsx
+++ b/components/assistant.tsx
@@ -11,6 +11,8 @@ interface AssistantProps {
   initialMessage?: string;
   developerPrompt?: string;
   onUserMessage?: (message: string) => void;
+  assistantAvatarUrl?: string;
+  showAssistantAvatar?: boolean;
 }
 
 export default function Assistant({
@@ -18,6 +20,8 @@ export default function Assistant({
   initialMessage,
   developerPrompt,
   onUserMessage,
+  assistantAvatarUrl,
+  showAssistantAvatar,
 }: AssistantProps) {
   const {
     chatMessages,
@@ -87,6 +91,8 @@ export default function Assistant({
         items={chatMessages}
         onSendMessage={handleSendMessage}
         onApprovalResponse={handleApprovalResponse}
+        assistantAvatarUrl={assistantAvatarUrl}
+        showAssistantAvatar={showAssistantAvatar}
       />
     </div>
   );

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -14,12 +14,16 @@ interface ChatProps {
   items: Item[];
   onSendMessage: (message: string) => void;
   onApprovalResponse: (approve: boolean, id: string) => void;
+  assistantAvatarUrl?: string;
+  showAssistantAvatar?: boolean;
 }
 
 const Chat: React.FC<ChatProps> = ({
   items,
   onSendMessage,
   onApprovalResponse,
+  assistantAvatarUrl,
+  showAssistantAvatar,
 }) => {
   const itemsEndRef = useRef<HTMLDivElement>(null);
   const [inputMessageText, setinputMessageText] = useState<string>("");
@@ -57,7 +61,11 @@ const Chat: React.FC<ChatProps> = ({
                   <ToolCall toolCall={item} />
                 ) : item.type === "message" ? (
                   <div className="flex flex-col gap-1">
-                    <Message message={item} />
+                    <Message
+                      message={item}
+                      assistantAvatarUrl={assistantAvatarUrl}
+                      showAssistantAvatar={showAssistantAvatar}
+                    />
                     {item.content &&
                       item.content[0].annotations &&
                       item.content[0].annotations.length > 0 && (

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -4,9 +4,15 @@ import ReactMarkdown from "react-markdown";
 
 interface MessageProps {
   message: MessageItem;
+  assistantAvatarUrl?: string;
+  showAssistantAvatar?: boolean;
 }
 
-const Message: React.FC<MessageProps> = ({ message }) => {
+const Message: React.FC<MessageProps> = ({
+  message,
+  assistantAvatarUrl,
+  showAssistantAvatar,
+}) => {
   return (
     <div className="text-sm">
       {message.role === "user" ? (
@@ -26,6 +32,13 @@ const Message: React.FC<MessageProps> = ({ message }) => {
       ) : (
         <div className="flex flex-col">
           <div className="flex">
+            {showAssistantAvatar && assistantAvatarUrl && (
+              <img
+                src={assistantAvatarUrl}
+                alt="avatar"
+                className="w-8 h-8 rounded-full mr-2"
+              />
+            )}
             <div className="mr-4 rounded-[16px] px-4 py-2 md:mr-24 text-black bg-white font-light">
               <div>
                 <ReactMarkdown>


### PR DESCRIPTION
## Summary
- show worker avatar bigger atop the preview panel
- allow `Assistant` to pass avatar info to `Chat`
- allow `Chat` to show an avatar next to assistant messages
- display the avatar beside preview messages

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc --noEmit` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6848416514308322a97bf9ea055b847f