### PR TITLE
Fix preview chat layout

### DIFF
--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -53,7 +53,7 @@ const Chat: React.FC<ChatProps> = ({
   return (
     <div className="flex justify-center items-center size-full">
       <div className="flex grow flex-col h-full max-w-[750px] gap-2">
-        <div className="h-[90vh] overflow-y-scroll px-10 flex flex-col">
+        <div className="flex-1 overflow-y-auto px-10 flex flex-col">
           <div className="mt-auto space-y-5 pt-4">
             {items.map((item, index) => (
               <React.Fragment key={index}>
@@ -88,7 +88,7 @@ const Chat: React.FC<ChatProps> = ({
             <div ref={itemsEndRef} />
           </div>
         </div>
-        <div className="flex-1 p-4 px-10">
+        <div className="p-4 px-10">
           <div className="flex items-center">
             <div className="flex w-full items-center pb-4 md:pb-1">
               <div className="flex w-full flex-col gap-1.5 rounded-[20px] p-2.5 pl-1.5 transition-colors bg-white border border-stone-200 shadow-sm">


### PR DESCRIPTION
## Summary
- keep chat list height flexible so avatar doesn't push it down
- let the message input auto-size rather than grow

## Testing
- `npx next lint` *(fails: Need to install the following packages: next@15.3.3)*

------
https://chatgpt.com/codex/tasks/task_e_6848454411c88322a088431dff43236b